### PR TITLE
DXKBCORE-45: Fix Domains and Motifs file reference

### DIFF
--- a/public/js/p3/widget/ColumnsGenome.js
+++ b/public/js/p3/widget/ColumnsGenome.js
@@ -507,7 +507,7 @@ define(['./formatter'], function (formatter) {
       group: 'Host Info'
     },
     host_gender: {
-      label: 'Host Gender',
+      label: 'Host Sex',
       field: 'host_gender',
       hidden: true,
       group: 'Host Info'

--- a/public/js/p3/widget/DataItemFormatter.js
+++ b/public/js/p3/widget/DataItemFormatter.js
@@ -3431,7 +3431,7 @@ define([
           text: 'host_common_name',
           editable: true
         }, {
-          name: 'Host Gender',
+          name: 'Host Sex',
           text: 'host_gender',
           editable: true
         }, {

--- a/public/js/p3/widget/GlobalSearch.js
+++ b/public/js/p3/widget/GlobalSearch.js
@@ -116,7 +116,7 @@ define([
             // clear = true;
             break;
           case 'protein_features':
-            Topic.publish('/navigate', { href: '/view/ProteinFeaturesList/?' + q });
+            Topic.publish('/navigate', { href: '/view/DomainsAndMotifsList/?' + q });
             break;
           case 'protein_structures':
             Topic.publish('/navigate', { href: '/view/ProteinStructureList/?' + q });
@@ -200,7 +200,7 @@ define([
           Topic.publish('/navigate', { href: '/view/GenomeList/?' + q });
           break;
         case 'protein_features':
-          Topic.publish('/navigate', { href: '/view/ProteinFeaturesList/?' + q });
+          Topic.publish('/navigate', { href: '/view/DomainsAndMotifsList/?' + q });
           break;
         case 'protein_structures':
           Topic.publish('/navigate', { href: '/view/ProteinStructureList/?' + q });


### PR DESCRIPTION
The Global Search for Domains and Motifs was using an old filename reference to point to a non-existent file. Fixed the reference.