### PR TITLE
v0.2.13 bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "p3-web",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "p3-web",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "hasInstallScript": true,
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p3-web",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "private": true,
   "scripts": {
     "start": "node ./bin/p3-web",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `p3-web` to v0.2.13 for a patch release. Updates version in package.json and package-lock.json; no functional changes.

<sup>Written for commit 6a4502eb2ee837955fbd9e16115369b14243bb9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

