### PR TITLE
Bump v0.2.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "p3-web",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "p3-web",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "hasInstallScript": true,
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p3-web",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "private": true,
   "scripts": {
     "start": "node ./bin/p3-web",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `p3-web` version from 0.2.13 to 0.2.14 in `package.json` and `package-lock.json` to tag the next patch release. No code changes.

<sup>Written for commit 66b189039384e250f7b5c39d5620991ec8fa5320. Summary will update on new commits. <a href="https://cubic.dev/pr/CEPI-dxkb/dxkb-web/pull/91?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

