### PR TITLE
DXKBCORE-146

### DIFF
--- a/public/js/p3/widget/app/StructureSequencePrediction.js
+++ b/public/js/p3/widget/app/StructureSequencePrediction.js
@@ -119,7 +119,7 @@ define([
         model_name: values.model_name,
         ca_only: values.ca_only,
         use_soluble_model: values.use_soluble_model,
-        omit_amino_acids: values.omit_amino_acids,
+        omit_AAs: values.omit_AAs,
         backbone_noise: values.backbone_noise,
         num_seq_per_target: values.num_seq_per_target,
         sampling_temp: values.sampling_temp,

--- a/public/js/p3/widget/app/templates/StructureSequencePrediction.html
+++ b/public/js/p3/widget/app/templates/StructureSequencePrediction.html
@@ -125,8 +125,8 @@
         </div>
         <div class="appRow">
           <label>Omit Amino Acids</label><br />
-          <div data-dojo-attach-point="omit_amino_acidsWidget" style="width:380px;"
-            data-dojo-type="p3/widget/WorkspaceFilenameValidationTextBox" name="omit_amino_acids" id="omit_amino_acids" required="false" value="X">
+          <div data-dojo-attach-point="omit_AAsWidget" style="width:380px;"
+            data-dojo-type="p3/widget/WorkspaceFilenameValidationTextBox" name="omit_AAs" id="omit_AAs" required="false" value="X">
           </div>
         </div>
         <div class="appRow">


### PR DESCRIPTION
Changing a variable name from omit_amino_acids to omit_AAs.

Don't need to submit the job, just need to verify that the param submitted is "omit_AAs" and no longer "omit_amino_acids" since the backend is expecting omit_AAs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the Structure Sequence Prediction parameter from omit_amino_acids to omit_AAs to match the backend API and ensure the option is passed through. Addresses DXKBCORE-146.

- **Bug Fixes**
  - JS: submit `omit_AAs` instead of `omit_amino_acids`.
  - UI: updated field name/id and attach point to `omit_AAs` in the template.

<sup>Written for commit 6bdb83b677b62db15e1523f337c6a9aaf4244847. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

